### PR TITLE
MOD: Use Throwable().getStackTrace() instead for better performance

### DIFF
--- a/library/src/main/java/top/shixinzhang/bitmapmonitor/BitmapMonitor.java
+++ b/library/src/main/java/top/shixinzhang/bitmapmonitor/BitmapMonitor.java
@@ -157,7 +157,7 @@ public class BitmapMonitor {
      */
     @Keep
     public static String dumpJavaStack() {
-        StackTraceElement[] st = Thread.currentThread().getStackTrace();
+        StackTraceElement[] st = new Throwable().getStackTrace();
         StringBuilder sb = new StringBuilder();
         sb.setLength(0);
 


### PR DESCRIPTION
JDK-6375302 : (thread) Thread.currentThread().getStackTrace(); is 10x slower vs getting stacktrace from throwable
See the link below for details: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6375302