### PR TITLE
[fix] BitmapFileWatcher delete old files

### DIFF
--- a/library/src/main/java/top/shixinzhang/bitmapmonitor/internal/BitmapFileWatcher.java
+++ b/library/src/main/java/top/shixinzhang/bitmapmonitor/internal/BitmapFileWatcher.java
@@ -7,6 +7,7 @@ import android.util.Log;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -123,10 +124,17 @@ public class BitmapFileWatcher {
         synchronized (LOCK) {
             // sort by last change time, oldest files will be deleted
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                mAllFiles.sort((file, t1) -> {
-                    if (file.lastModified() > t1.lastModified()) return 1;
-                    else if (file.lastModified() < t1.lastModified()) return -1;
-                    return 0;
+                HashMap<File, Long> fileByTime = new HashMap<>();
+                mAllFiles.sort((file1, file2) -> {
+                    Long t1 = fileByTime.get(file1);
+                    Long t2 = fileByTime.get(file2);
+                    if (t1 == null) {
+                        fileByTime.put(file1, t1 = file1.lastModified());
+                    }
+                    if (t2 == null) {
+                        fileByTime.put(file2, t2 = file2.lastModified());
+                    }
+                    return t1.compareTo(t2);
                 });
             }
             // deleting files


### PR DESCRIPTION
This commit fixes a bug where the modification time of files was altered when deleting old files


### stack ： 

10-31 17:42:36.919 12552 14353 E AndroidRuntime: java.lang.IllegalArgumentException: Comparison method violates its general contract!
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at java.util.TimSort.mergeHi(TimSort.java:899)
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at java.util.TimSort.mergeAt(TimSort.java:516)
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at java.util.TimSort.mergeCollapse(TimSort.java:439)
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at java.util.TimSort.sort(TimSort.java:245)
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at java.util.Arrays.sort(Arrays.java:1424)
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at java.util.concurrent.CopyOnWriteArrayList.sort(CopyOnWriteArrayList.java:882)
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at top.shixinzhang.bitmapmonitor.internal.BitmapFileWatcher.deleteFileFromRootDirectory(BitmapFileWatcher.java:126)
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at top.shixinzhang.bitmapmonitor.internal.BitmapFileWatcher.access$400(BitmapFileWatcher.java:20)
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at top.shixinzhang.bitmapmonitor.internal.BitmapFileWatcher$WatchFileRunnable.run(BitmapFileWatcher.java:201)
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
10-31 17:42:36.919 12552 14353 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:920)